### PR TITLE
Vantus Runes for ToS 

### DIFF
--- a/BigBrother.toc
+++ b/BigBrother.toc
@@ -1,4 +1,4 @@
-## Interface: 70100
+## Interface: 70200
 ## Title: Big Brother
 ## Notes: Checks Raid Buffs/Flasks/Consumables. Tunable alerts for misdirects, taunts, cc breakage, rez, dispel and interrupt
 ## Notes-deDE: Prüft Raidbuffs/Fläschchen & warnt wer Verwandlungen/Untote fesseln unterbricht.

--- a/SpellData.lua
+++ b/SpellData.lua
@@ -40,6 +40,7 @@ vars.SpellData.VantusRunes = {
 	192770, -- Spellblade Aluriel
 	192771, -- Tichondrius
 	192772, -- High Botanist Tel'arn
+	192773, -- Krosus
 	192774, -- Star Augur Etraeus
 	192775, -- Grand Magistrix Elisande
 	192776, -- Gul'dan


### PR DESCRIPTION
vars.SpellData.VantusRunes = {
	-- Emerald Nightmare
	192761, -- Nythndra
	192765, -- Elerethe Renferal
	191464, -- Ursoc
	192762, -- Il'gynoth
	192763, -- Dragons of Nightmare
	192766, -- Cenarius
	192764, -- Xavius
	-- Trial of Valor
	229174, -- Odyn
	229175, -- Guarm
	229176, -- Helya
	-- Nighthold
	192767, -- Skorpyron
	192768, -- Chronomatic Anomaly
	192769, -- Trilliax
	192770, -- Spellblade Aluriel
	192771, -- Tichondrius
	192772, -- High Botanist Tel'arn
	192773, -- Krosus
	192774, -- Star Augur Etraeus
	192775, -- Grand Magistrix Elisande
	192776, -- Gul'dan
	-- Tomb of Sargeras
	237821, -- Goroth
	237828, -- Demonic Inquisition
	237824, -- Harjatan
	237822, -- Sisters of the Moon
	237826, -- Mistress Sassz'ine
	237827, -- The Desolate Host
	237823, -- Fel Titan (Maiden of Vigilance maybe. Fixed id will be asap)
	237820, -- Fallen Avatar
	237825, -- Kil'jaeden
}

